### PR TITLE
feat: resizing support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,8 +27,11 @@
             android:enabled="true"
             android:exported="true" />
 
-        <activity android:name=".VSCodeActivity"
-            android:configChanges="orientation|screenSize">
+        <activity
+            android:name=".VSCodeActivity"
+            android:configChanges="orientation|screenSize"
+            android:resizeableActivity="true"
+        >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
@@ -41,7 +44,10 @@
                     android:scheme="http" />
             </intent-filter>
         </activity>
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:resizeableActivity="true"
+        >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
 
         <activity
             android:name=".VSCodeActivity"
-            android:configChanges="orientation|screenSize"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden|keyboard|navigation|fontScale|uiMode"
             android:resizeableActivity="true"
         >
             <intent-filter>


### PR DESCRIPTION
In addition to supporting window resizing, I added flags to avoid reloading the browser for the most diverse triggers that do not interfere with usage.

This prevents, for example, that the browser reloads when inserting and removing an external keyboard.

Tests performed in the DEX mode of the Samsung Galaxy TAB S6 Lite.